### PR TITLE
virus sample counts: use total and not average when combining samples

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -402,11 +402,6 @@
           locationSamples.forEach(sample => {
             taxonomyTree[taxid][locationGroupName] += taxonomyTree[taxid][sample] || 0;
           });
-
-          // Calculate the average by dividing by the number of samples
-          taxonomyTree[taxid][locationGroupName] = Math.round(
-            taxonomyTree[taxid][locationGroupName] / locationSamples.length
-          );
         }
       });
 


### PR DESCRIPTION
If we decide to use a larger unit of analysis we generally are going to be more interested in totals that averages.  This tells us how many observations something is based on in total, and it's ok if some samples have very little data.